### PR TITLE
Fix realm_set

### DIFF
--- a/src/kdd/kctl.rs
+++ b/src/kdd/kctl.rs
@@ -56,6 +56,21 @@ impl Kdd {
 		Ok(())
 	}
 
+	pub fn k_get_contexts(&self) -> Result<Vec<String>, KddError> {
+	   match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "get-contexts", "-o=name"], false) {
+			Ok(ctxs) => Ok(ctxs.lines().map(|s| s.trim().to_string()).collect()),
+			Err(e) => Err(KddError::KubectlFail(e.to_string()))
+		}
+	}
+
+	pub fn k_create_context(&self, ctx: &str) -> Result<(), KddError> {
+	   match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "set-context", ctx], false) {
+			Ok(_) => Ok(()),
+			Err(e) => Err(KddError::KubectlFail(e.to_string()))
+		}
+	}
+
+
 	pub fn k_current_context(&self) -> Result<String, KddError> {
 		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "current-context"], false) {
 			Ok(name) => Ok(name.trim().to_string()),

--- a/src/kdd/realm.rs
+++ b/src/kdd/realm.rs
@@ -213,7 +213,18 @@ impl Kdd {
 		match self.realms.get(name) {
 			None => Err(KddError::RealmNotFound(name.to_string())),
 			Some(realm) => match &realm.context {
-				Some(ctx) => self.k_set_context(&ctx),
+				Some(ctx) => {
+				    let ctxs = self.k_get_contexts()?;
+					let ctxs_set: HashSet<_> = HashSet::from_iter(ctxs);
+
+					if !ctxs_set.contains(ctx) {
+					   self.k_create_context(&ctx);
+					}
+
+					self.k_set_context(&ctx);
+
+					Ok(())
+				},
 				None => Err(KddError::RealmHasNoContext(name.to_string())),
 			},
 		}


### PR DESCRIPTION
Previously, the function attempted to set the kubectl config context even if it didn't exist. I added two functions in Kdd impl:

-     k_get_contexts: Retrieves the available kubectl config contexts as a Vec<String>.
-     k_create_context: Allows for the creation of a new kubectl context if needed.

Modified `realm_set` function to first check if the context exists (if it doesn't it creates one) and then set it.