### PR TITLE
Kubernetes context commands

### DIFF
--- a/src/cmd/argc.rs
+++ b/src/cmd/argc.rs
@@ -16,6 +16,7 @@ pub fn cmd_app() -> Command<'static> {
 		.subcommand(sub_kaction(("kdelete", "kd")))
 		.subcommand(sub_klog())
 		.subcommand(sub_kexec())
+		.subcommand(sub_kctx())
 		.subcommand(sub_version())
 }
 
@@ -94,6 +95,28 @@ fn sub_klog() -> Command<'static> {
 				.help("Service names that match the pod label run: system-_service_name_ (e.g., 'web-server' for label.run = cstar-web-server)"),
 		)
 		.arg(arg_root_dir())
+}
+
+fn sub_kctx() -> Command<'static> {
+	Command::new("kctx")
+		.about("Manage Kubernetes contexts")
+		.subcommand(
+			Command::new("list")
+				.about("List all available Kubernetes contexts")
+				.arg(arg_root_dir()),
+		)
+		.subcommand(
+			Command::new("create")
+				.about("Create a new Kubernetes context")
+				.arg(Arg::new("name").help("Name of the Kubernetes context to create").required(true))
+				.arg(arg_root_dir()),
+		)
+		.subcommand(
+			Command::new("delete")
+				.about("Delete an existing Kubernetes context")
+				.arg(Arg::new("name").help("Name of the Kubernetes context to delete").required(true))
+				.arg(arg_root_dir()),
+		)
 }
 
 fn sub_kexec() -> Command<'static> {

--- a/src/kdd/kctl.rs
+++ b/src/kdd/kctl.rs
@@ -35,10 +35,7 @@ impl Kdd {
 		let k8s_out_files = self.k_templates(realm, names, false)?;
 
 		if realm.confirm_delete {
-			println!(
-				"Are you sure you want to delete the services in realm {}? (YES to continue, anything else to cancel)",
-				realm.name
-			);
+			println!("Are you sure you want to delete the services in realm {}? (YES to continue, anything else to cancel)", realm.name);
 			let mut guess = String::new();
 			stdin().read_line(&mut guess).expect("Failed to read line");
 			if guess.trim() != "YES" {
@@ -54,6 +51,13 @@ impl Kdd {
 		}
 
 		Ok(())
+	}
+
+	pub fn k_create_ctx(&self, ctx: &str) -> Result<(), KddError> {
+		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "set-context", ctx], false) {
+			Ok(_) => Ok(()),
+			Err(e) => Err(KddError::KubectlFail(e.to_string())),
+		}
 	}
 
 	pub fn k_current_context(&self) -> Result<String, KddError> {

--- a/src/kdd/kctl.rs
+++ b/src/kdd/kctl.rs
@@ -60,6 +60,13 @@ impl Kdd {
 		}
 	}
 
+	pub fn k_list_ctx(&self) -> Result<Vec<String>, KddError> {
+		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "get-contexts", "-o=name"], false) {
+			Ok(ctxs) => Ok(ctxs.lines().map(|s| s.trim().to_string()).collect()),
+			Err(e) => Err(KddError::KubectlFail(e.to_string())),
+		}
+	}
+
 	pub fn k_current_context(&self) -> Result<String, KddError> {
 		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "current-context"], false) {
 			Ok(name) => Ok(name.trim().to_string()),

--- a/src/kdd/kctl.rs
+++ b/src/kdd/kctl.rs
@@ -67,6 +67,13 @@ impl Kdd {
 		}
 	}
 
+	pub fn k_delete_ctx(&self, ctx: &str) -> Result<(), KddError> {
+		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "delete-context", ctx], false) {
+			Ok(_) => Ok(()),
+			Err(e) => Err(KddError::KubectlFail(e.to_string())),
+		}
+	}
+
 	pub fn k_current_context(&self) -> Result<String, KddError> {
 		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "current-context"], false) {
 			Ok(name) => Ok(name.trim().to_string()),

--- a/src/kdd/kctl.rs
+++ b/src/kdd/kctl.rs
@@ -53,21 +53,21 @@ impl Kdd {
 		Ok(())
 	}
 
-	pub fn k_create_ctx(&self, ctx: &str) -> Result<(), KddError> {
+	pub fn k_create_context(&self, ctx: &str) -> Result<(), KddError> {
 		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "set-context", ctx], false) {
 			Ok(_) => Ok(()),
 			Err(e) => Err(KddError::KubectlFail(e.to_string())),
 		}
 	}
 
-	pub fn k_list_ctx(&self) -> Result<Vec<String>, KddError> {
+	pub fn k_list_context(&self) -> Result<Vec<String>, KddError> {
 		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "get-contexts", "-o=name"], false) {
 			Ok(ctxs) => Ok(ctxs.lines().map(|s| s.trim().to_string()).collect()),
 			Err(e) => Err(KddError::KubectlFail(e.to_string())),
 		}
 	}
 
-	pub fn k_delete_ctx(&self, ctx: &str) -> Result<(), KddError> {
+	pub fn k_delete_context(&self, ctx: &str) -> Result<(), KddError> {
 		match exec_to_stdout(Some(&self.dir), "kubectl", &["config", "delete-context", ctx], false) {
 			Ok(_) => Ok(()),
 			Err(e) => Err(KddError::KubectlFail(e.to_string())),


### PR DESCRIPTION
Added kubernetes context commands: 

- `kdd kctx list` - list available kubectl contexts
- `kdd kctx create <name>` - create a kubectl context
- `kdd kctx delete <name>` - delete a kubectl context

Additionally, when user wants to switch to a another realm and the context doesn't exist, it will prompt the user to type YES to create it or type anything other to cancel.